### PR TITLE
JMH Benchmarks: Avoid byte array copy for reads in NMA valueSerializer 

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -16,10 +16,10 @@ dependencies {
 }
 
 jmh {
-    warmupIterations.set(3)
-    iterations.set(3)
+    warmupIterations.set(5)
+    iterations.set(5)
     fork.set(1)
     forceGC.set(true)
     failOnError.set(true)
-    jvmArgs.set(listOf("-Xmx2G"))
+    jvmArgs.set(listOf("-Xmx4G"))
 }

--- a/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/OffHeapGetPutBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/OffHeapGetPutBenchmark.kt
@@ -5,6 +5,7 @@ import com.target.nativememoryallocator.benchmarks.impl.RocksDBOffHeapCache
 import com.target.nativememoryallocator.benchmarks.impl.UnimplementedOffHeapCache
 import mu.KotlinLogging
 import org.openjdk.jmh.annotations.*
+import java.nio.ByteBuffer
 
 private val logger = KotlinLogging.logger {}
 
@@ -26,7 +27,7 @@ open class OffHeapGetPutBenchmark {
     )
     var cacheType: String = ""
 
-    private var cache: OffHeapCache<String, ByteArray> = UnimplementedOffHeapCache
+    private var cache: OffHeapCache<String, ByteBuffer> = UnimplementedOffHeapCache
 
     @State(Scope.Thread)
     open class ThreadState {
@@ -60,7 +61,7 @@ open class OffHeapGetPutBenchmark {
         }
 
         for (i in 0 until NUM_ENTRIES) {
-            cache.put(key = i.toString(), value = ByteArray(VALUE_SIZE))
+            cache.put(key = i.toString(), value = ByteBuffer.wrap(ByteArray(VALUE_SIZE)))
         }
 
         cache.logMetadata()
@@ -78,7 +79,7 @@ open class OffHeapGetPutBenchmark {
     @Benchmark
     @Group("read_only")
     @GroupThreads(8)
-    fun readOnly(threadState: ThreadState): ByteArray? {
+    fun readOnly(threadState: ThreadState): ByteBuffer? {
         val key = threadState.nextIndex().toString()
         val value = cache.get(key = key)
         if (value == null) {
@@ -92,13 +93,13 @@ open class OffHeapGetPutBenchmark {
     @GroupThreads(8)
     fun writeOnly(threadState: ThreadState) {
         val key = threadState.nextIndex().toString()
-        cache.put(key = key, value = ByteArray(VALUE_SIZE))
+        cache.put(key = key, value = ByteBuffer.wrap(ByteArray(VALUE_SIZE)))
     }
 
     @Benchmark
     @Group("readwrite")
     @GroupThreads(6)
-    fun readwrite_get(threadState: ThreadState): ByteArray? {
+    fun readwrite_get(threadState: ThreadState): ByteBuffer? {
         val key = threadState.nextIndex().toString()
         val value = cache.get(key = key)
         if (value == null) {
@@ -112,7 +113,7 @@ open class OffHeapGetPutBenchmark {
     @GroupThreads(2)
     fun readwrite_put(threadState: ThreadState) {
         val key = threadState.nextIndex().toString()
-        cache.put(key = key, value = ByteArray(VALUE_SIZE))
+        cache.put(key = key, value = ByteBuffer.wrap(ByteArray(VALUE_SIZE)))
     }
 
 }

--- a/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/impl/NMAOffHeapCache.kt
+++ b/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/impl/NMAOffHeapCache.kt
@@ -18,7 +18,7 @@ private val logger = KotlinLogging.logger {}
 class NMAOffHeapCache : OffHeapCache<String, ByteBuffer> {
 
     init {
-        logger.info { "initializing NMAOffHeapCache with asByteBuffer change" }
+        logger.info { "initializing NMAOffHeapCache" }
     }
 
     private val nativeMemoryAllocator = NativeMemoryAllocatorBuilder(

--- a/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/impl/RocksDBOffHeapCache.kt
+++ b/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/impl/RocksDBOffHeapCache.kt
@@ -4,13 +4,14 @@ import com.target.nativememoryallocator.benchmarks.OffHeapCache
 import mu.KotlinLogging
 import org.rocksdb.RocksDB
 import java.io.File
+import java.nio.ByteBuffer
 
 private val logger = KotlinLogging.logger {}
 
 /**
  * RocksDB implementation of OffHeapCache.
  */
-class RocksDBOffHeapCache : OffHeapCache<String, ByteArray> {
+class RocksDBOffHeapCache : OffHeapCache<String, ByteBuffer> {
 
     private val rocksDbDir: String
 
@@ -28,12 +29,12 @@ class RocksDBOffHeapCache : OffHeapCache<String, ByteArray> {
         rocksDB = RocksDB.open(rocksDbDir)
     }
 
-    override fun get(key: String): ByteArray? {
-        return rocksDB.get(key.toByteArray())
+    override fun get(key: String): ByteBuffer? {
+        return rocksDB.get(key.toByteArray())?.let { ByteBuffer.wrap(it) }
     }
 
-    override fun put(key: String, value: ByteArray) {
-        rocksDB.put(key.toByteArray(), value)
+    override fun put(key: String, value: ByteBuffer) {
+        rocksDB.put(key.toByteArray(), value.array())
     }
 
     override fun size(): Int {

--- a/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/impl/UnimplementedOffHeapCache.kt
+++ b/benchmarks/src/jmh/kotlin/com/target/nativememoryallocator/benchmarks/impl/UnimplementedOffHeapCache.kt
@@ -1,18 +1,19 @@
 package com.target.nativememoryallocator.benchmarks.impl
 
 import com.target.nativememoryallocator.benchmarks.OffHeapCache
+import java.nio.ByteBuffer
 
 /**
  * Unimplemented OffHeapCache.
  * All methods throw NotImplementedError.
  */
-object UnimplementedOffHeapCache : OffHeapCache<String, ByteArray> {
+object UnimplementedOffHeapCache : OffHeapCache<String, ByteBuffer> {
 
-    override fun get(key: String): ByteArray? {
+    override fun get(key: String): ByteBuffer? {
         throw NotImplementedError()
     }
 
-    override fun put(key: String, value: ByteArray) {
+    override fun put(key: String, value: ByteBuffer) {
         throw NotImplementedError()
     }
 


### PR DESCRIPTION
GCP VM Perf results with this change are below, compare with baseline: https://github.com/target/native_memory_allocator/wiki/Benchmark-results-in-GCP-VM 

* NMA tps is 3.7x more in read_only test (257K -> 970K)
* NMA tps is 2.1x more in readwrite test (256K -> 555K)
* Results for RocksDB do not change.

```

~/jdk-17.0.6/bin/java -jar ./benchmarks-jmh.jar -wi 10 -i 20 -f 1 -gc true -foe true -tg 32 -jvmArgs '-Xmx4G -Drocksdb.dir=/tmp/tmpfs/rocksdb' read_only

Benchmark                         (cacheType)   Mode  Cnt       Score      Error  Units
OffHeapGetPutBenchmark.read_only          NMA  thrpt   20  970632.328 ± 8836.803  ops/s
OffHeapGetPutBenchmark.read_only      RocksDB  thrpt   20  120857.160 ± 1444.857  ops/s


~/jdk-17.0.6/bin/java -jar ./benchmarks-jmh.jar -wi 10 -i 20 -f 1 -gc true -foe true -tg 32 -jvmArgs '-Xmx4G -Drocksdb.dir=/tmp/tmpfs/rocksdb' write_only

Benchmark                          (cacheType)   Mode  Cnt       Score      Error  Units
OffHeapGetPutBenchmark.write_only          NMA  thrpt   20  199977.906 ± 6923.452  ops/s
OffHeapGetPutBenchmark.write_only      RocksDB  thrpt   20    2466.037 ±  492.823  ops/s


~/jdk-17.0.6/bin/java -jar ./benchmarks-jmh.jar -wi 10 -i 20 -f 1 -gc true -foe true -tg 24,8 -jvmArgs '-Xmx4G -Drocksdb.dir=/tmp/tmpfs/rocksdb'   readwrite

Benchmark                                       (cacheType)   Mode  Cnt       Score       Error  Units
OffHeapGetPutBenchmark.readwrite                        NMA  thrpt   20  555568.405 ± 30179.022  ops/s
OffHeapGetPutBenchmark.readwrite:readwrite_get          NMA  thrpt   20  481717.573 ± 26025.353  ops/s
OffHeapGetPutBenchmark.readwrite:readwrite_put          NMA  thrpt   20   73850.832 ±  4198.050  ops/s
OffHeapGetPutBenchmark.readwrite                    RocksDB  thrpt   20  109377.958 ± 17557.734  ops/s
OffHeapGetPutBenchmark.readwrite:readwrite_get      RocksDB  thrpt   20  107904.098 ± 17242.323  ops/s
OffHeapGetPutBenchmark.readwrite:readwrite_put      RocksDB  thrpt   20    1473.860 ±   429.475  ops/s
```